### PR TITLE
Support --tracker from transmission's TR_TORRENT_TRACKERS

### DIFF
--- a/gazelleorigin/__main__.py
+++ b/gazelleorigin/__main__.py
@@ -42,10 +42,10 @@ class TrackerData:
 TRACKERS = [
     TrackerData(base_url="https://redacted.sh",
             api_key_env="RED_API_KEY",
-            aliases=["red", "flacsfor.me"]),
+            aliases=["red", "flacsfor.me", "flacsfor.me:443"]),
     TrackerData(base_url="https://orpheus.network",
             api_key_env="OPS_API_KEY",
-            aliases=["ops", "opsfet.ch"])
+            aliases=["ops", "opsfet.ch", "home.opsfet.ch:443"])
 ]
 
 class GazelleOrigin:


### PR DESCRIPTION
hi, transmission's on complete script automatically sets TR_TORRENT_TRACKERS, TR_TORRENT_DIR, TR_TORRENT_NAME, and TR_TORRENT_HASH

i want to use it like this

```sh
RED_API_KEY=123 \
OPS_API_KEY=123 \
gazelle-origin \
  --tracker "$TR_TORRENT_TRACKERS" \
  --out "$TR_TORRENT_DIR/$TR_TORRENT_NAME/origin.yaml" \
  "$TR_TORRENT_HASH"
```

but it only works if gazelle-origin understands trackers like `flacsfor.me:443` which is what `TR_TORRENT_TRACKERS` contains

thanks!