### PR TITLE
Fixes: handle torrents with unicode or special characters, etc.

### DIFF
--- a/gazelleorigin/__init__.py
+++ b/gazelleorigin/__init__.py
@@ -1,1 +1,1 @@
-from .core import GazelleAPI, GazelleAPIError
+from gazelleorigin.core import GazelleAPI, GazelleAPIError

--- a/gazelleorigin/__main__.py
+++ b/gazelleorigin/__main__.py
@@ -18,7 +18,7 @@ except ModuleNotFoundError:
 
 import yaml
 from hashlib import sha1
-from . import GazelleAPI, GazelleAPIError
+from core import GazelleAPI, GazelleAPIError
 
 EXIT_CODES = {
     'hash': 3,

--- a/gazelleorigin/__main__.py
+++ b/gazelleorigin/__main__.py
@@ -18,7 +18,7 @@ except ModuleNotFoundError:
 
 import yaml
 from hashlib import sha1
-from core import GazelleAPI, GazelleAPIError
+from gazelleorigin.core import GazelleAPI, GazelleAPIError
 
 EXIT_CODES = {
     'hash': 3,

--- a/gazelleorigin/__main__.py
+++ b/gazelleorigin/__main__.py
@@ -116,7 +116,13 @@ class GazelleOrigin:
             sys.exit(EXIT_CODES['tracker'])
 
         # Search for the tracker with an alias matching the input
-        tracker = next((x for x in TRACKERS if args.ORIGIN_TRACKER.lower() in x.aliases), None)
+        tracker = next(
+            (
+                x for x in TRACKERS
+                if any(alias in args.ORIGIN_TRACKER.lower() for alias in x.aliases)
+            ),
+            None
+        )
         if not tracker:
             print('Invalid tracker: {0}'.format(args.ORIGIN_TRACKER), file=sys.stderr)
             sys.exit(EXIT_CODES['tracker'])

--- a/gazelleorigin/__main__.py
+++ b/gazelleorigin/__main__.py
@@ -116,13 +116,7 @@ class GazelleOrigin:
             sys.exit(EXIT_CODES['tracker'])
 
         # Search for the tracker with an alias matching the input
-        tracker = next(
-            (
-                x for x in TRACKERS
-                if any(alias in args.ORIGIN_TRACKER.lower() for alias in x.aliases)
-            ),
-            None
-        )
+        tracker = next((x for x in TRACKERS if any(alias in args.ORIGIN_TRACKER.lower() for alias in x.aliases)), None)
         if not tracker:
             print('Invalid tracker: {0}'.format(args.ORIGIN_TRACKER), file=sys.stderr)
             sys.exit(EXIT_CODES['tracker'])

--- a/gazelleorigin/core.py
+++ b/gazelleorigin/core.py
@@ -134,7 +134,7 @@ class GazelleAPI:
             'Log':                     '{0}%'.format(torrent['logScore']) if torrent['hasLog'] else '',
             'Format':                  torrent['format'],
             'Encoding':                torrent['encoding'],
-            'Directory':               torrent['filePath'],
+            'Directory':               html.unescape(torrent['filePath']),
             'Size':                    torrent['size'],
             'File count':              torrent['fileCount'],
             'Info hash':               torrent.get("infoHash", hash or "Unknown"), # OPS fallback

--- a/gazelleorigin/core.py
+++ b/gazelleorigin/core.py
@@ -161,7 +161,9 @@ class GazelleAPI:
 
         result += yaml.dump({'Files': file_list}, width=float('inf'), allow_unicode=True)
 
-        groupDescription = html.unescape(group.get('bbBody') or group.get('wikiBBcode')).strip('\r\n')
+        description_raw = group.get('bbBody') or group.get('wikiBBcode') or ''
+        groupDescription = html.unescape(description_raw).strip('\r\n')
+
         if groupDescription:
             groupDescription = textwrap.indent(groupDescription, '  ', lambda line: True)
             result += '\n\nDescription: |-\n{0}\n\n'.format(groupDescription)

--- a/gazelleorigin/core.py
+++ b/gazelleorigin/core.py
@@ -165,7 +165,10 @@ class GazelleAPI:
         groupDescription = html.unescape(description_raw).strip('\r\n')
 
         if groupDescription:
-            groupDescription = textwrap.indent(groupDescription, '  ', lambda line: True)
-            result += '\n\nDescription: |-\n{0}\n\n'.format(groupDescription)
+            # Normalize all lines to have 2 spaces
+            lines = groupDescription.splitlines()
+            normalized = '\n'.join('  ' + line.lstrip() for line in lines)
+
+            result += '\n\nDescription: |-\n{0}\n\n'.format(normalized)
 
         return result

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="gazelle-origin",
-    version="2.2.1",
+    version="3.0.1",
     author="x1ppy",
     author_email="",
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,6 @@ setuptools.setup(
     version="3.0.1",
     author="x1ppy",
     author_email="",
-    packages=[
-      'gazelleorigin',
-    ],
     entry_points={
       'console_scripts': [
         'gazelle-origin = gazelleorigin.__main__:main',
@@ -19,6 +16,8 @@ setuptools.setup(
     description="Gazelle origin.yaml generator",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    packages=setuptools.find_packages(),
+    include_package_data=True,
     url="https://github.com/x1ppy/gazelle-origin",
     python_requires='>=3.5.2',
     install_requires=[


### PR DESCRIPTION
# Fix YAML handling, Unicode paths, and description parsing

While processing a set of torrent files, I encountered multiple issues that prevented proper execution or YAML parsing.

## 1. Control characters breaking `yaml.load()`

Some torrent metadata included unprintable control characters, which caused `yaml.load()` to fail with a `ReaderError`.  
To fix this, I added a sanitization step that strips control characters from the YAML string before loading it.  
🔗 [Commit](https://github.com/spinfast319/gazelle-origin/pull/6/commits/8ba0158028e416adf380ebfc7843a27726cc42b7)

<details>
<summary>Error traceback</summary>

```
yaml.reader.ReaderError: unacceptable character #x0008: special characters are not allowed
  in "<unicode string>", position 3582
```
</details>

---

## 2. HTML-escaped Unicode in file paths

In Linux, HTML-encoded characters (like `&#26376;`) in the `Directory` field were not automatically rendered, causing shell script failures when working with file paths.

This didn’t occur on macOS (likely due to locale or terminal differences).  
Fixed by applying `html.unescape()` to `torrent['filePath']`.

🔗 [Commit](https://github.com/spinfast319/gazelle-origin/pull/6/commits/0fc1b11cd7c49a12e7d3b3a344b9e964eae64eb1)

<details>
<summary>Command output</summary>

```
mv: cannot move 'origin.yaml' to 'Music12TB/Nadja - (1989) '$'æ...'': No such file or directory
```
</details>

---

## 3. Empty torrent description caused crashes

If the torrent had no description (`None`), the script would crash when passing it to `html.unescape()`.  
This was handled by falling back to an empty string.  
🔗 [Commit](https://github.com/spinfast319/gazelle-origin/pull/6/commits/288ece3aef337c669fcd86fb242f03122da587fb)

---

## 4. Invalid YAML due to inconsistent indentation in `Description`

When using `Description: |-`, some lines (like URLs) had inconsistent indentation compared to the rest of the block, breaking YAML parsing.

Example:

```yaml
Description: |-
   https://beatport.com/...
  __________________________ ← fewer spaces here
```

Fixed by normalizing indentation using `.lstrip()` and padding all lines uniformly.

🔗 [Commit](https://github.com/spinfast319/gazelle-origin/pull/6/commits/544a41ddc60372c92825e93fadd6b1d4163a1c56)

---

## 5. Debugging improvements

The script is now debuggeable via `python -m` thanks to a small fix in import structure.


No errors after scanning 52.600 torrents.